### PR TITLE
Add compatibility with options v2 API

### DIFF
--- a/inc/popup.js
+++ b/inc/popup.js
@@ -9,6 +9,17 @@
 
 		$('#popup-tab-hosts-filter').on('keyup', function() { popup_nav('hosts'); });
 		$('#popup-tab-services-filter').on('keyup', function() { popup_nav('services'); });
+
+		$('.open-options').click(function() {
+			if (chrome.runtime.openOptionsPage) {
+				// New way to open options pages, if supported (Chrome 42+).
+				chrome.runtime.openOptionsPage();
+			} else {
+				// Reasonable fallback.
+				window.open(chrome.runtime.getURL('options.html'));
+			}
+		});
+
 	});
 
 	table_classes = {

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,13 @@
     "page": "background.html",
     "persistent": true
   },
+
   "options_page": "options.html",
+
+  "options_ui": {
+    "page": "options.html",
+    "chrome_style": true
+  },
 
   "icons": {
     "48": "img/icon_48.png",

--- a/popup.html
+++ b/popup.html
@@ -58,7 +58,7 @@
 
 			<div class="alert alert-success" id="popup-tab-overview-alert-0" role="alert"><b>Good job!</b> Looks like everything is working as it should. Coffee granted.</div>
 			<div class="alert alert-warning" id="popup-tab-overview-alert-1" role="alert"><b>Hmm..</b> We got a warning, maybe something is about to break.</div>
-			<div class="alert alert-warning" id="popup-tab-overview-alert-new" role="alert"><b>Welcome!</b> Time to setup your first Icinga instance. <a href="options.html" target="_blank">Click here to get to the options right away.</a></div>
+			<div class="alert alert-warning" id="popup-tab-overview-alert-new" role="alert"><b>Welcome!</b> Time to setup your first Icinga instance. <a href="#" class="open-options">Click here to get to the options right away.</a></div>
 			<div class="alert alert-danger" id="popup-tab-overview-alert-2" role="alert"><b>Houston, we have a problem!</b> Something seems broken, sorry.</div>
 
 			<div id="popup-tab-overview-downs"></div>
@@ -84,7 +84,7 @@
 				<a href="https://github.com/bashgeek/icinga-multi-status" target="_blank"><img src="img/github.jpg" border="0" alt="GitHub"></a>
 				<a href="https://bashgeek.net" target="_blank"><img src="img/bashgeek.jpg" border="0" alt="bashgeek.net"></a>
 			</div>
-			<a href="options.html" target="_blank" class="btn btn-sm btn-default">Options</a>
+			<a href="#" class="btn btn-sm btn-default open-options">Options</a>
 			<a href="help.html" target="_blank" class="btn btn-sm btn-default">Help</a>
 		</div>
 


### PR DESCRIPTION
This adds options v2 compatibility (which is supported in Chrome 42+).
Firefox doesn't implement the older options API, so it is needed to get the addon running there properly.

See: https://developer.chrome.com/extensions/optionsV2