### PR TITLE
Replace chrome.extension.sendRequest with runtime.sendMesssage

### DIFF
--- a/inc/background.js
+++ b/inc/background.js
@@ -163,7 +163,7 @@ var bg = {
 
 	// Bind Request Listener
 	listener: function() {
-		chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
+		browser.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 			switch(request.request) {
 				case 'data':
 					sendResponse({ 'state': 'ok', 'hosts': bg.data_hosts });

--- a/inc/popup.js
+++ b/inc/popup.js
@@ -30,7 +30,8 @@
 
 		switch(to) {
 			case 'services':
-				chrome.extension.sendRequest({ request: 'data' }, function(e) {
+				var sending = browser.runtime.sendMessage({request: 'data' });
+				sending.then(function(e) {
 					$('#popup-tab-services-tables').empty();
 
 					if (e.state == 'ok') {
@@ -111,13 +112,16 @@
 							}
 						}
 					} else {
-						$('#popup-tab-hosts-tables').html('An error occured - could not connect with background task.');
+						$('#popup-tab-services-tables').html('An error occured - could not connect with background task.');
 					}
+				}, function(e) {
+					$('#popup-tab-services-tables').html('An error occured - could not connect with background task.');
 				});
 			break;
 
 			case 'hosts':
-				chrome.extension.sendRequest({ request: 'data' }, function(e) {
+				var sending = browser.runtime.sendMessage({request: 'data' });
+				sending.then(function(e) {
 					$('#popup-tab-hosts-tables').empty();
 
 					if (e.state == 'ok') {
@@ -181,11 +185,14 @@
 					} else {
 						$('#popup-tab-hosts-tables').html('An error occured - could not connect with background task.');
 					}
+				}, function(e) {
+					$('#popup-tab-hosts-tables').html('An error occured - could not connect with background task.');
 				});
 			break;
 
 			case 'overview':
-				chrome.extension.sendRequest({ request: 'data' }, function(e) {
+				var sending = browser.runtime.sendMessage({request: 'data' });
+				sending.then(function(e) {
 					$('#popup-tab-overview-table').find('tbody').empty();
 					$('#popup-tab-overview-downs').empty();
 					$('#popup-tab-overview .alert').each(function(){ $(this).hide(); });
@@ -336,6 +343,8 @@
 					} else {
 						$('#popup-tab-overview').html('An error occured - could not connect with background task.');
 					}
+				}, function(e) {
+					$('#popup-tab-overview').html('An error occured - could not connect with background task.');
 				});
 			break;
 		}


### PR DESCRIPTION
Chrome has deprecated the sendRequest API in Chrome 33.
This updates the communication to use the runtime.sendMessage API (available in Chrome 26+).
Firefox doesn't seem to implement sendRequest, so it is needed to run the addon there.

See:
- https://developer.chrome.com/extensions/extension#method-sendRequest
- https://developer.chrome.com/extensions/runtime#method-sendMessage
